### PR TITLE
add docker net's config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:20.04
+
+RUN sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list  
+
+RUN apt-get update
+
+
+RUN apt-get install -y jq curl 
+
+RUN rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY . .
+
+ENTRYPOINT ["/bin/bash", "-c", "sleep 10 && ./sdcs-test.sh 3 && tail -f /dev/null"]

--- a/README.md
+++ b/README.md
@@ -29,5 +29,6 @@ Simple test for SDCS
          ```
       3. 可以通过`/usr/local/bin/bash --version`确认新bash的版本。
       4. 使用`/usr/local/bin/bash ./sdcs-test.sh {cache_server_number}`运行测试脚本。
+1. docker 容器运行脚本时，为了能够使运行该脚本的容器直接访问主机的端口，设置 HOST_BASE=host.docker.internal
 
 

--- a/sdcs-test.sh
+++ b/sdcs-test.sh
@@ -20,7 +20,10 @@ which jq >/dev/null 2>&1 || {
 }
 
 PORT_BASE=9526
+
 HOST_BASE=127.0.0.1
+# HOST_BASE=host.docker.internal
+
 MAX_ITER=500
 DELETED_KEYS=()
 _DELETED_KEYS_GENERATED=0


### PR DESCRIPTION

## target

run this shell through docker image on windows system

## how to run

create a docker file in the same dir of `sdcs-test.sh` as follow:

``` Dockerfile
FROM ubuntu:20.04

RUN sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list  
RUN apt-get update

RUN apt-get install -y jq curl 

RUN rm -rf /var/lib/apt/lists/*

WORKDIR /app
COPY . .

ENTRYPOINT ["/bin/bash", "-c", "sleep 10 && ./sdcs-test.sh 3 && tail -f /dev/null"]
```
and run the image if the cache servers(containers) are correctly running on your host machine(windows)
don't forget to set cache servers' port accesible on your host machine

## proof

it works well

![image](https://github.com/user-attachments/assets/e00b1167-2966-4b14-bdd3-6425b98d770d)
